### PR TITLE
Add tkinter GUI and refactor PersonalPasswords into generator module

### DIFF
--- a/personalpasswords/README.md
+++ b/personalpasswords/README.md
@@ -1,0 +1,76 @@
+# PersonalPasswords - OSINT Wordlist Generator
+
+PersonalPasswords is a local desktop utility that generates custom password wordlists from names/keywords and optional dates. It applies capitalization and reverse variants, optional character substitutions, optional external wordlist merging, and optional length filtering.
+
+## Legal and Ethical Use
+This tool is for **authorized security testing, password auditing, lab work, and defensive assessments only**.
+Do not use it against systems, accounts, or data without explicit permission.
+
+## Features
+- Simple desktop GUI (tkinter)
+- Names/keywords input (one per line)
+- Optional dates input in `DDMMYYYY` format (invalid dates are skipped and reported)
+- Optional character substitutions
+- Optional alphabetical sorting
+- Duplicate removal (enforced internally)
+- Optional external wordlist merge
+- Optional min/max length filtering
+- Automatic unique output filename generation (`PasswordList.txt`, `PasswordList_1.txt`, etc.)
+
+## Project Structure
+```
+personalpasswords/
+  app.py
+  generator.py
+  requirements.txt
+  README.md
+```
+
+## Run from Source
+From the `personalpasswords` directory:
+
+```bash
+python -m pip install -r requirements.txt
+python app.py
+```
+
+> Note: `tkinter` is included with most Python installers, so no extra GUI package is required.
+
+## Build a Windows Executable (PyInstaller)
+From the `personalpasswords` directory:
+
+```bash
+python -m pip install -r requirements.txt
+pyinstaller --onefile --windowed app.py --name PersonalPasswords
+```
+
+The executable will be created in:
+- `dist/PersonalPasswords.exe`
+
+## How to Use the GUI
+1. Enter names/keywords (one per line). This field is required.
+2. Optionally enter dates in `DDMMYYYY` format (one per line).
+3. Optionally choose an output path. If blank, output defaults to `PasswordList.txt` in the app directory.
+4. Optionally select an external wordlist to merge.
+5. Optionally set minimum and/or maximum password length.
+6. Click **Generate Wordlist**.
+7. Review status messages for:
+   - validation errors
+   - skipped invalid dates
+   - output file path
+   - total unique passwords
+   - whether external wordlist merge occurred
+8. Use **Open Output Folder** to open the folder containing the output file.
+
+## Date Format
+Expected date format is `DDMMYYYY`.
+Example:
+- `01012000` (1 January 2000)
+
+## Output Location
+- If no output path is selected: saved in the app directory as `PasswordList.txt` (or uniquely suffixed).
+- If an output path is selected: saved there, with unique filename handling if needed.
+
+## Privacy and Safety
+All generation happens locally on your machine.
+The tool does not upload, transmit, or sync generated passwords.

--- a/personalpasswords/app.py
+++ b/personalpasswords/app.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tkinter as tk
+from pathlib import Path
+from tkinter import filedialog, ttk
+
+from generator import (
+    DEFAULT_FILENAME,
+    create_unique_filename,
+    filter_by_length,
+    generate_passwords,
+    merge_wordlist,
+    modify_dates,
+)
+
+
+class PersonalPasswordsApp:
+    def __init__(self, root: tk.Tk) -> None:
+        self.root = root
+        self.root.title("PersonalPasswords - OSINT Wordlist Generator")
+        self.root.geometry("860x740")
+
+        self.output_var = tk.StringVar()
+        self.wordlist_var = tk.StringVar()
+        self.min_len_var = tk.StringVar()
+        self.max_len_var = tk.StringVar()
+
+        self.use_subs_var = tk.BooleanVar(value=True)
+        self.sort_var = tk.BooleanVar(value=True)
+        self.remove_dupes_var = tk.BooleanVar(value=True)
+
+        self.last_output_file: Path | None = None
+
+        self._build_ui()
+
+    def _build_ui(self) -> None:
+        frame = ttk.Frame(self.root, padding=12)
+        frame.pack(fill="both", expand=True)
+
+        ttk.Label(frame, text="Names / keywords (one per line):").pack(anchor="w")
+        self.names_text = tk.Text(frame, height=8)
+        self.names_text.pack(fill="x", pady=(0, 10))
+
+        ttk.Label(frame, text="Dates in DDMMYYYY format (optional, one per line):").pack(anchor="w")
+        self.dates_text = tk.Text(frame, height=6)
+        self.dates_text.pack(fill="x", pady=(0, 10))
+
+        self._file_picker_row(frame, "Output file:", self.output_var, self._browse_output, save=True)
+        self._file_picker_row(frame, "External wordlist (optional):", self.wordlist_var, self._browse_wordlist, save=False)
+
+        lens = ttk.Frame(frame)
+        lens.pack(fill="x", pady=(8, 8))
+        ttk.Label(lens, text="Minimum length (optional):").grid(row=0, column=0, sticky="w")
+        ttk.Entry(lens, textvariable=self.min_len_var, width=12).grid(row=0, column=1, padx=(8, 18), sticky="w")
+        ttk.Label(lens, text="Maximum length (optional):").grid(row=0, column=2, sticky="w")
+        ttk.Entry(lens, textvariable=self.max_len_var, width=12).grid(row=0, column=3, padx=(8, 0), sticky="w")
+
+        opts = ttk.LabelFrame(frame, text="Options", padding=8)
+        opts.pack(fill="x", pady=(6, 10))
+        ttk.Checkbutton(opts, text="Enable character substitutions", variable=self.use_subs_var).pack(anchor="w")
+        ttk.Checkbutton(opts, text="Sort output alphabetically", variable=self.sort_var).pack(anchor="w")
+        ttk.Checkbutton(opts, text="Remove duplicates (enforced)", variable=self.remove_dupes_var).pack(anchor="w")
+
+        btns = ttk.Frame(frame)
+        btns.pack(fill="x", pady=(4, 10))
+        ttk.Button(btns, text="Generate Wordlist", command=self.generate_wordlist).pack(side="left", padx=(0, 8))
+        ttk.Button(btns, text="Clear Inputs", command=self.clear_inputs).pack(side="left", padx=(0, 8))
+        ttk.Button(btns, text="Open Output Folder", command=self.open_output_folder).pack(side="left")
+
+        ttk.Label(frame, text="Status:").pack(anchor="w")
+        self.status_text = tk.Text(frame, height=12, state="disabled", wrap="word")
+        self.status_text.pack(fill="both", expand=True)
+
+        ttk.Label(
+            frame,
+            text=(
+                "For authorized security testing, password auditing, lab work, "
+                "and defensive assessments only."
+            ),
+            foreground="#555",
+        ).pack(anchor="w", pady=(8, 0))
+
+    def _file_picker_row(self, parent: ttk.Frame, label: str, variable: tk.StringVar, command, save: bool) -> None:
+        row = ttk.Frame(parent)
+        row.pack(fill="x", pady=(4, 6))
+        ttk.Label(row, text=label).pack(anchor="w")
+        inner = ttk.Frame(row)
+        inner.pack(fill="x")
+        ttk.Entry(inner, textvariable=variable).pack(side="left", fill="x", expand=True, padx=(0, 8))
+        ttk.Button(inner, text="Save As..." if save else "Browse...", command=command).pack(side="left")
+
+    def _browse_output(self) -> None:
+        chosen = filedialog.asksaveasfilename(
+            title="Choose output file",
+            defaultextension=".txt",
+            filetypes=[("Text files", "*.txt"), ("All files", "*.*")],
+            initialfile=DEFAULT_FILENAME,
+        )
+        if chosen:
+            self.output_var.set(chosen)
+
+    def _browse_wordlist(self) -> None:
+        chosen = filedialog.askopenfilename(
+            title="Select external wordlist",
+            filetypes=[("Text files", "*.txt"), ("All files", "*.*")],
+        )
+        if chosen:
+            self.wordlist_var.set(chosen)
+
+    def _append_status(self, message: str) -> None:
+        self.status_text.configure(state="normal")
+        self.status_text.insert("end", message + "\n")
+        self.status_text.see("end")
+        self.status_text.configure(state="disabled")
+
+    def _clear_status(self) -> None:
+        self.status_text.configure(state="normal")
+        self.status_text.delete("1.0", "end")
+        self.status_text.configure(state="disabled")
+
+    def _parse_optional_int(self, value: str, field_name: str) -> tuple[int | None, str | None]:
+        cleaned = value.strip()
+        if not cleaned:
+            return None, None
+        try:
+            return int(cleaned), None
+        except ValueError:
+            return None, f"{field_name} must be an integer."
+
+    def generate_wordlist(self) -> None:
+        self._clear_status()
+
+        names = [line.strip() for line in self.names_text.get("1.0", "end").splitlines() if line.strip()]
+        raw_dates = [line.strip() for line in self.dates_text.get("1.0", "end").splitlines() if line.strip()]
+
+        if not names:
+            self._append_status("Error: Names / keywords are required.")
+            return
+
+        min_len, min_err = self._parse_optional_int(self.min_len_var.get(), "Minimum length")
+        max_len, max_err = self._parse_optional_int(self.max_len_var.get(), "Maximum length")
+        if min_err:
+            self._append_status(f"Error: {min_err}")
+            return
+        if max_err:
+            self._append_status(f"Error: {max_err}")
+            return
+        if min_len is not None and max_len is not None and max_len < min_len:
+            self._append_status("Error: Maximum length cannot be smaller than minimum length.")
+            return
+
+        modified_dates, invalid_dates = modify_dates(raw_dates)
+        if invalid_dates:
+            self._append_status("Skipped invalid dates: " + ", ".join(invalid_dates))
+
+        output_input = self.output_var.get().strip()
+        if output_input:
+            desired_output = Path(output_input)
+        else:
+            desired_output = Path(__file__).resolve().parent / DEFAULT_FILENAME
+
+        output_file = create_unique_filename(desired_output)
+        passwords = generate_passwords(names, modified_dates, use_subs=self.use_subs_var.get())
+
+        passwords, merged, merge_error = merge_wordlist(passwords, self.wordlist_var.get().strip() or None)
+        if merge_error:
+            self._append_status(f"Warning: {merge_error}")
+
+        passwords = filter_by_length(passwords, min_len, max_len)
+        ordered = sorted(passwords) if self.sort_var.get() else list(passwords)
+
+        try:
+            output_file.parent.mkdir(parents=True, exist_ok=True)
+            with output_file.open("w", encoding="utf-8") as fh:
+                for pwd in ordered:
+                    fh.write(pwd + "\n")
+        except OSError as exc:
+            self._append_status(f"Error: Could not write output file. {exc}")
+            return
+
+        self.last_output_file = output_file
+        self._append_status("Success: Password list generated.")
+        self._append_status(f"Output file: {output_file}")
+        self._append_status(f"Total unique passwords generated: {len(passwords)}")
+        self._append_status(f"External wordlist merged: {'Yes' if merged else 'No'}")
+
+    def clear_inputs(self) -> None:
+        self.names_text.delete("1.0", "end")
+        self.dates_text.delete("1.0", "end")
+        self.output_var.set("")
+        self.wordlist_var.set("")
+        self.min_len_var.set("")
+        self.max_len_var.set("")
+        self.use_subs_var.set(True)
+        self.sort_var.set(True)
+        self.remove_dupes_var.set(True)
+        self._clear_status()
+        self.last_output_file = None
+
+    def open_output_folder(self) -> None:
+        if self.last_output_file:
+            folder = self.last_output_file.parent
+        else:
+            folder = Path(self.output_var.get()).expanduser().parent if self.output_var.get().strip() else Path(__file__).resolve().parent
+
+        try:
+            if sys.platform.startswith("win"):
+                os.startfile(folder)  # type: ignore[attr-defined]
+            elif sys.platform == "darwin":
+                subprocess.run(["open", str(folder)], check=False)
+            else:
+                subprocess.run(["xdg-open", str(folder)], check=False)
+            self._append_status(f"Opened output folder: {folder}")
+        except Exception as exc:
+            self._append_status(f"Error: Could not open folder. {exc}")
+
+
+def main() -> None:
+    root = tk.Tk()
+    app = PersonalPasswordsApp(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/personalpasswords/generator.py
+++ b/personalpasswords/generator.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+DEFAULT_FILENAME = "PasswordList.txt"
+INT_LIST = list(range(10))
+SPECIAL_CHAR_LIST = ["!", "@", "#", "$", "%", "^", "&", "*", "?", "~", "-", "_", "+", "=", "*"]
+
+CHAR_SUBSTITUTIONS = {
+    "a": "@",
+    "i": "!",
+    "o": "0",
+    "l": "1",
+    "t": "7",
+    "g": "9",
+    "b": "8",
+    "z": "2",
+    "e": "3",
+    "s": "5",
+}
+
+
+def substitute_chars(name: str) -> str:
+    return "".join([CHAR_SUBSTITUTIONS.get(c, c) for c in name])
+
+
+def capitalization_variants(name: str) -> set[str]:
+    return {name.lower(), name.upper(), name.capitalize()}
+
+
+def reversed_name(name: str) -> str:
+    return name[::-1]
+
+
+def delimiter_variants(name1: str, name2: str) -> set[str]:
+    return {f"{name1}_{name2}", f"{name1}-{name2}", f"{name1}.{name2}"}
+
+
+def modify_dates(date_list: Iterable[str]) -> tuple[list[str], list[str]]:
+    mod_dates = set()
+    valid_inputs = []
+    invalid_dates = []
+
+    for raw in date_list:
+        date = str(raw).strip()
+        if not date:
+            continue
+        if not (len(date) == 8 and date.isdigit()):
+            invalid_dates.append(date)
+            continue
+        try:
+            date_obj = datetime.strptime(date, "%d%m%Y")
+            valid_inputs.append(date)
+            mod_dates.update(
+                [date_obj.strftime(fmt) for fmt in ("%d%b%Y", "%Y", "%b", "%d", "%d%b", "%b%Y")]
+            )
+        except ValueError:
+            invalid_dates.append(date)
+
+    return list(set(map(str, valid_inputs)) | mod_dates), invalid_dates
+
+
+def generate_passwords(name_list: list[str], date_list: list[str], use_subs: bool = True) -> set[str]:
+    password_set = set()
+    modified_names = set()
+
+    for name in name_list:
+        modified_names.update(capitalization_variants(name))
+        modified_names.add(reversed_name(name))
+        if use_subs:
+            modified_names.add(substitute_chars(name))
+
+    all_names = list(set(name_list) | modified_names)
+
+    for name in all_names:
+        password_set.add(name)
+        for i in INT_LIST:
+            password_set.add(f"{name}{i}")
+            for char in SPECIAL_CHAR_LIST:
+                password_set.add(f"{name}{i}{char}")
+                for name2 in all_names:
+                    password_set.add(f"{name}{char}{name2}")
+                    password_set.add(f"{name}{i}{char}{name2}")
+                    password_set.update(delimiter_variants(name, name2))
+        for date in date_list:
+            password_set.add(f"{name}{date}")
+            password_set.add(f"{name}@{date}")
+            for char in SPECIAL_CHAR_LIST:
+                password_set.add(f"{name}{date}{char}")
+                password_set.add(f"{name}{char}{date}")
+                password_set.add(f"{name}{char}{date}{char}")
+
+    password_set.update(date_list)
+    return password_set
+
+
+def create_unique_filename(base_name: str | Path) -> Path:
+    target = Path(base_name)
+    counter = 1
+    candidate = target
+    while candidate.exists():
+        candidate = target.with_name(f"{target.stem}_{counter}{target.suffix or '.txt'}")
+        counter += 1
+    return candidate
+
+
+def merge_wordlist(password_set: set[str], wordlist_path: str | Path | None) -> tuple[set[str], bool, str | None]:
+    if not wordlist_path:
+        return password_set, False, None
+
+    path = Path(wordlist_path)
+    if not path.exists() or not path.is_file():
+        return password_set, False, f"Wordlist path not found: {path}"
+
+    try:
+        with path.open("r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                stripped = line.strip()
+                if stripped:
+                    password_set.add(stripped)
+        return password_set, True, None
+    except OSError as exc:
+        return password_set, False, f"Failed to merge wordlist: {exc}"
+
+
+def filter_by_length(passwords: set[str], min_len: int | None, max_len: int | None) -> set[str]:
+    return {
+        pwd
+        for pwd in passwords
+        if (min_len is None or len(pwd) >= min_len) and (max_len is None or len(pwd) <= max_len)
+    }

--- a/personalpasswords/requirements.txt
+++ b/personalpasswords/requirements.txt
@@ -1,0 +1,3 @@
+# tkinter is included with most standard Python installations.
+# Install pyinstaller for building a standalone executable.
+pyinstaller>=6.0


### PR DESCRIPTION
### Motivation
- Provide a simple cross-platform desktop UI so non-technical users can generate OSINT-based password wordlists without a terminal.
- Preserve and reuse the existing generation logic while separating concerns so the GUI is only responsible for presentation and validation.
- Make distribution easier for Windows users by adding PyInstaller packaging instructions and clear run/build documentation.

### Description
- Refactored core logic into a new `generator.py` containing `substitute_chars()`, `capitalization_variants()`, `reversed_name()`, `delimiter_variants()`, `modify_dates()`, `generate_passwords()`, `create_unique_filename()`, `merge_wordlist()`, and `filter_by_length()` and converted file handling to use `pathlib` and structured invalid-date reporting.
- Added a `app.py` tkinter desktop GUI titled `PersonalPasswords - OSINT Wordlist Generator` with multiline inputs for names and dates, output and external-wordlist pickers, min/max length fields, checkboxes for substitutions/sorting/duplicate removal, and buttons for `Generate Wordlist`, `Clear Inputs`, and `Open Output Folder` plus a status area for validation and results.
- Implemented GUI validations and behaviors: names required, optional DDMMYYYY date parsing with skipped-invalid reporting, integer checks for min/max length, `max >= min` enforcement, default output `PasswordList.txt` when blank, and automatic unique filename creation when the target exists.
- Added `README.md` with usage, legal/ethical disclaimer, date format, and PyInstaller build instructions, plus a minimal `requirements.txt` noting `pyinstaller>=6.0` (and that `tkinter` is usually bundled).

### Testing
- Compiled the new modules with `python -m py_compile app.py generator.py` to verify syntax and the compilation step succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f344fc312c832cb1fe42c59d94cbb1)